### PR TITLE
Update MaintainScrollPosition.UWP.csproj

### DIFF
--- a/MaintainScrollPosition/MaintainScrollPosition/MaintainScrollPosition.UWP/MaintainScrollPosition.UWP.csproj
+++ b/MaintainScrollPosition/MaintainScrollPosition/MaintainScrollPosition.UWP/MaintainScrollPosition.UWP.csproj
@@ -147,7 +147,7 @@
       <Version>16.3.0.21</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Forms" Version="3.0.0.561731" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.1" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MaintainScrollPosition\MaintainScrollPosition.csproj">


### PR DESCRIPTION
Resolved below dependabot errors.
https://github.com/SyncfusionExamples/xamarin-maintain-the-scroll-position-of-ListView-after-clearing-the-filter-at-runtime/